### PR TITLE
🔨  add .gitignore to initial project

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -162,4 +162,22 @@ fn create_template(path: &str) {
         ),
         "Failed to create config file"
     );
+
+    // create .gitignore file
+    let gitignore_text = "\
+        # certificates // keys in the data dir\n\
+        data/certificate.crt\n\
+        data/private.key\n\
+        data/profile.pfx\n\
+        \n\
+        # log\n\
+        log.txt\n\
+    ";
+    expect_pretty(
+        fs::write(
+            format!("{}/.gitignore", path), 
+            gitignore_text.as_bytes()
+        ), 
+        "Failed to create .gitignore file"
+    );
 }


### PR DESCRIPTION
This lets the cli create a .gitignore file in new projects. I got the idea of doing this when I created my own gemini capsule with `aerozine` and published it on GitHub.
For now, I excluded the `log.txt` file and the keyfiles in the `data/` dir from git. If there are any objections or other ideas, please comment.